### PR TITLE
Fix diff cleanup regex

### DIFF
--- a/app/utils/diff.spec.ts
+++ b/app/utils/diff.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { modificationsRegex } from './diff';
+
+// Utility function mirroring the sanitize logic used in UserMessage.tsx
+function sanitize(content: string) {
+  return content.replace(modificationsRegex, '');
+}
+
+describe('modificationsRegex', () => {
+  it('removes modification block even when not at start', () => {
+    const input = [
+      '[Model: test]\n\n',
+      '[Provider: foo]\n\n',
+      '<bolt_file_modifications><diff path="/foo">hi</diff></bolt_file_modifications>\n\n',
+      'User message',
+    ].join('');
+
+    const output = sanitize(input);
+
+    expect(output).not.toContain('bolt_file_modifications');
+    expect(output.trim().endsWith('User message')).toBe(true);
+  });
+});

--- a/app/utils/diff.ts
+++ b/app/utils/diff.ts
@@ -2,8 +2,13 @@ import { createTwoFilesPatch } from 'diff';
 import type { FileMap } from '~/lib/stores/files';
 import { MODIFICATIONS_TAG_NAME } from './constants';
 
+// Matches the <bolt_file_modifications> block anywhere in the text.
+// The previous pattern anchored the tag to the start of the string which meant
+// user messages containing the model/provider preamble wouldn't be cleaned up
+// correctly. By removing the beginning anchor we allow stripping the block no
+// matter where it appears.
 export const modificationsRegex = new RegExp(
-  `^<${MODIFICATIONS_TAG_NAME}>[\\s\\S]*?<\\/${MODIFICATIONS_TAG_NAME}>\\s+`,
+  `<${MODIFICATIONS_TAG_NAME}>[\\s\\S]*?<\\/${MODIFICATIONS_TAG_NAME}>\\s*`,
   'g',
 );
 


### PR DESCRIPTION
## Summary
- remove start anchor in modifications regex so diffs anywhere in the text are stripped
- add regression test for the regex logic

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68420c8ed3b08323b68e95796474ea7b